### PR TITLE
SPD-2025 Store the StoreLinkr product metafields, plus version bump to 2.19.0

### DIFF
--- a/assets/storelinkr_admin.css
+++ b/assets/storelinkr_admin.css
@@ -291,6 +291,10 @@ p.storelinkr-lead {
     content: "\f512" !important;
 }
 
+.storelinkr_metafields_options a::before {
+    content: "\f535" !important;
+}
+
 label.storelinkr-attachment-name {
     width: 200px !important;
 }
@@ -320,6 +324,17 @@ label.storelinkr-attachment-name {
 .storelinkr-product-page-content .outofstock {
     color: #a44;
     font-weight: 700;
+}
+
+.storelinkr-product-page-content .sl-muted {
+    color: #777;
+}
+
+.storelinkr-product-page-content pre.sl-metafield-json {
+    margin: 0;
+    max-height: 200px;
+    overflow: auto;
+    white-space: pre-wrap;
 }
 
 .notice-storelinkr {

--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@ Release date: 2026-08-13
 #### Enhancements
 
 * Store all StoreLinkr product metafields, like OE numbers and manufacturer codes, as product meta
+* Every product of a variant keeps its own metafields on the variation itself
 * New Metafields tab on the product page in the admin, showing the metafields of the product
 * New template function storeLinkrGetProductMetafields() to use the metafields in your theme
 * New filter storelinkr_metafield_show_in_rest to expose a metafield through the WordPress REST API

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,16 @@
 
+= 2.18.1 =
+
+Release date: 2026-08-13
+
+#### Enhancements
+
+* Version bump for WordPress 7.1 support
+
+#### Bugfixes
+
+None
+
 = 2.12.0 =
 
 Release date: 2025-10-22

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,19 @@
 
+= 2.19.0 =
+
+Release date: 2026-08-13
+
+#### Enhancements
+
+* Store all StoreLinkr product metafields, like OE numbers and manufacturer codes, as product meta
+* New Metafields tab on the product page in the admin, showing the metafields of the product
+* New template function storeLinkrGetProductMetafields() to use the metafields in your theme
+* New filter storelinkr_metafield_show_in_rest to expose a metafield through the WordPress REST API
+
+#### Bugfixes
+
+None
+
 = 2.18.1 =
 
 Release date: 2026-08-13

--- a/class.storelinkr-admin.php
+++ b/class.storelinkr-admin.php
@@ -20,6 +20,7 @@ class StoreLinkrAdmin
         add_filter('woocommerce_product_data_tabs', [$this, 'storeLinkrProductCustomTab'], 99, 1);
         add_action('woocommerce_product_data_panels', [$this, 'productAttachmentTabContent']);
         add_action('woocommerce_product_data_panels', [$this, 'productStockLocationsTabContent']);
+        add_action('woocommerce_product_data_panels', [$this, 'productMetafieldsTabContent']);
         add_action('edit_form_after_title', [$this, 'storeLinkrProductMessage']);
         add_action('admin_head', function () {
             $screen = get_current_screen();
@@ -259,6 +260,12 @@ class StoreLinkrAdmin
             'class' => ['show_if_simple', 'show_if_variable', 'show_if_grouped'],
             'priority' => 60,
         ];
+        $tabs['storelinkr_metafields'] = [
+            'label' => __('Metafields', 'storelinkr'),
+            'target' => 'storelinkr_metafields',
+            'class' => ['show_if_simple', 'show_if_variable', 'show_if_grouped'],
+            'priority' => 61,
+        ];
 
         return $tabs;
     }
@@ -320,6 +327,113 @@ class StoreLinkrAdmin
 
         echo '</div>';
         echo '</div>';
+    }
+
+    public function productMetafieldsTabContent()
+    {
+        global $post;
+
+        echo '<div id="storelinkr_metafields" class="panel woocommerce_options_panel storelinkr-product-page-content">';
+        echo '<div class="options_group">';
+
+        if ($post && $post->post_type === 'product') {
+            $product = wc_get_product($post->ID);
+            $variations = [];
+
+            if ($product instanceof WC_Product_Variable) {
+                $variations = $product->get_available_variations('object');
+            } elseif ($product) {
+                $variations[] = $product;
+            }
+
+            foreach ($variations as $productData) {
+                $metafields = StoreLinkrMetafieldHelper::getProductMetafields($productData);
+
+                echo '<h3 class="sl-tab-heading">' . esc_attr($productData->get_name()) . '</h3>';
+                echo '<table class="wp-list-table widefat striped">';
+
+                if (count($metafields) >= 1) {
+                    echo '<thead>';
+                    echo '<th>' . esc_html__('Metafield', 'storelinkr') . '</th>';
+                    echo '<th>' . esc_html__('Value', 'storelinkr') . '</th>';
+                    echo '</thead>';
+
+                    foreach ($metafields as $metafield) {
+                        echo '<tr>';
+                        echo '<td><strong>' . esc_html($metafield['name']) . '</strong><br />';
+                        echo '<code>' . esc_html($metafield['key']) . '</code></td>';
+                        echo '<td>';
+                        $this->renderMetafieldValue($metafield);
+                        echo '</td>';
+                        echo '</tr>';
+                    }
+                } else {
+                    echo '<tr>';
+                    echo '<td><i>' . esc_html__('No metafields found for this product.', 'storelinkr') . '</i>';
+                    echo '<br /><br />';
+                    echo '<a href="https://portal.storelinkr.com" target="_blank">';
+                    echo esc_html__('Manage metafields', 'storelinkr');
+                    echo '<span class="dashicons dashicons-external"></span>';
+                    echo '</a>';
+                    echo '</td>';
+                    echo '</tr>';
+                }
+
+                echo '</table>';
+            }
+        }
+
+        echo '</div>';
+        echo '</div>';
+    }
+
+    private function renderMetafieldValue(array $metafield): void
+    {
+        if (is_array($metafield['decoded'])) {
+            $rows = $metafield['decoded'];
+            $isTable = count($rows) >= 1
+                && array_is_list($rows)
+                && count(array_filter($rows, 'is_array')) === count($rows);
+
+            if ($isTable === true) {
+                echo '<table class="wp-list-table widefat">';
+                foreach ($rows as $row) {
+                    echo '<tr>';
+                    foreach ($row as $column => $value) {
+                        echo '<td><span class="sl-muted">' . esc_html((string)$column) . '</span> ';
+                        echo esc_html(is_scalar($value) ? (string)$value : (string)wp_json_encode($value));
+                        echo '</td>';
+                    }
+                    echo '</tr>';
+                }
+                echo '</table>';
+
+                return;
+            }
+
+            echo '<pre class="sl-metafield-json">' . esc_html((string)wp_json_encode(
+                $metafield['decoded'],
+                JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
+            )) . '</pre>';
+
+            return;
+        }
+
+        if ($metafield['type'] === 'html_text') {
+            echo wp_kses_post($metafield['value']);
+
+            return;
+        }
+
+        if ($metafield['type'] === 'boolean') {
+            echo ($metafield['value'] === '1')
+                ? esc_html__('Yes', 'storelinkr')
+                : esc_html__('No', 'storelinkr');
+
+            return;
+        }
+
+        echo nl2br(esc_html($metafield['value']));
     }
 
     public function productStockLocationsTabContent()

--- a/class.storelinkr-rest-api.php
+++ b/class.storelinkr-rest-api.php
@@ -1255,6 +1255,7 @@ class StoreLinkrRestApi
             'inStock' => $request->get_param('inStock'),
             'stockSupplier' => $request->get_param('stockSupplier'),
             'metadata' => $request->get_param('metadata'),
+            'metafields' => $request->get_param('metafields'),
             'importSource' => $request->get_param('importSource'),
             'site' => $request->get_param('site'),
             'stockLocations' => $request->get_param('stockLocations'),

--- a/helpers/class.storelinkr-metafield-helper.php
+++ b/helpers/class.storelinkr-metafield-helper.php
@@ -1,0 +1,301 @@
+<?php
+
+if (!defined('ABSPATH')) {
+    // Exit if accessed directly
+    exit;
+}
+
+/**
+ * Stores the StoreLinkr product metafields (OE numbers, manufacturer codes, marketing content, ...)
+ * as WordPress post meta on the WooCommerce product.
+ */
+class StoreLinkrMetafieldHelper
+{
+
+    public const META_KEY_PREFIX = 'storelinkr_';
+
+    /**
+     * Holds the definitions (name, type and meta key) of the metafields currently known for a
+     * product. Needed to clean up meta of metafields that were removed inside StoreLinkr.
+     */
+    public const INDEX_META_KEY = '_storelinkr_metafields';
+
+    /**
+     * All metafield definitions seen on this shop, used to register the meta keys in WordPress.
+     */
+    public const REGISTRY_OPTION = 'storelinkr_metafield_definitions';
+
+    /**
+     * These types hold a JSON encoded value, the raw JSON is stored as post meta.
+     */
+    public const JSON_TYPES = [
+        'json',
+        'datatable',
+    ];
+
+    public const DEFAULT_TYPE = 'single_text';
+
+    /**
+     * The meta_key column of WordPress is a varchar(255), a longer key is refused or truncated by
+     * the database. Note that the index on the column only covers the first 191 characters.
+     */
+    public const MAX_META_KEY_LENGTH = 255;
+
+    private const KEY_HASH_LENGTH = 8;
+
+    /**
+     * Meta keys used by the plugin itself, a metafield may never overwrite one of these.
+     */
+    private const RESERVED_META_KEYS = [
+        'storelinkr_variant_ids',
+    ];
+
+    /**
+     * Write all metafields of a product, and remove the ones that no longer exist in StoreLinkr.
+     *
+     * @param WC_Product|WC_Product_Variable|WC_Product_Variation $product
+     * @param array $metafields
+     * @return void
+     */
+    public static function applyToProduct($product, array $metafields): void
+    {
+        $definitions = [];
+        $metaKeys = [];
+
+        foreach ($metafields as $metafield) {
+            $metafield = (array)$metafield;
+
+            if (empty($metafield['name'])) {
+                continue;
+            }
+
+            $metaKey = self::buildMetaKey((string)$metafield['name']);
+            if ($metaKey === null) {
+                continue;
+            }
+
+            $type = (!empty($metafield['type'])) ? (string)$metafield['type'] : self::DEFAULT_TYPE;
+            $value = self::formatValue($type, $metafield['value'] ?? null);
+
+            if ($value === null) {
+                continue;
+            }
+
+            $product->update_meta_data($metaKey, $value);
+
+            $definitions[] = [
+                'name' => (string)$metafield['name'],
+                'type' => $type,
+                'key' => $metaKey,
+            ];
+            $metaKeys[] = $metaKey;
+        }
+
+        foreach (self::readIndex($product) as $previousDefinition) {
+            if (empty($previousDefinition['key'])) {
+                continue;
+            }
+
+            if (in_array($previousDefinition['key'], $metaKeys, true)) {
+                continue;
+            }
+
+            $product->delete_meta_data($previousDefinition['key']);
+        }
+
+        $product->update_meta_data(self::INDEX_META_KEY, json_encode($definitions));
+
+        self::rememberDefinitions($definitions);
+    }
+
+    /**
+     * All metafields of a product, including the decoded value for the JSON based types.
+     *
+     * @param WC_Product|WC_Product_Variable|WC_Product_Variation $product
+     * @return array
+     */
+    public static function getProductMetafields($product): array
+    {
+        $metafields = [];
+
+        foreach (self::readIndex($product) as $definition) {
+            if (empty($definition['key']) || empty($definition['name'])) {
+                continue;
+            }
+
+            $type = (!empty($definition['type'])) ? (string)$definition['type'] : self::DEFAULT_TYPE;
+            $value = $product->get_meta($definition['key'], true);
+
+            if ($value === '' || $value === null) {
+                continue;
+            }
+
+            $metafields[] = [
+                'name' => (string)$definition['name'],
+                'type' => $type,
+                'key' => (string)$definition['key'],
+                'value' => $value,
+                'decoded' => self::decodeValue($type, $value),
+            ];
+        }
+
+        return $metafields;
+    }
+
+    /**
+     * Register all known metafields as post meta, so WordPress knows the meta keys of this shop and
+     * everything that expects registered meta can work with them.
+     *
+     * WooCommerce products are readable through the WordPress REST API, and metafields can hold
+     * internal data like purchase prices, so they stay out of the REST API unless a shop opts in
+     * with the storelinkr_metafield_show_in_rest filter.
+     */
+    public static function registerPostMeta(): void
+    {
+        foreach (self::getDefinitions() as $metaKey => $definition) {
+            register_post_meta('product', $metaKey, [
+                'type' => 'string',
+                'description' => (!empty($definition['name'])) ? (string)$definition['name'] : $metaKey,
+                'single' => true,
+                'show_in_rest' => (bool)apply_filters(
+                    'storelinkr_metafield_show_in_rest',
+                    false,
+                    $metaKey,
+                    $definition
+                ),
+                'auth_callback' => function () {
+                    return current_user_can('manage_woocommerce');
+                },
+            ]);
+        }
+    }
+
+    /**
+     * @return array meta key => ['name' => string, 'type' => string]
+     */
+    public static function getDefinitions(): array
+    {
+        $definitions = get_option(self::REGISTRY_OPTION, []);
+
+        if (!is_array($definitions)) {
+            return [];
+        }
+
+        return $definitions;
+    }
+
+    public static function buildMetaKey(string $name): ?string
+    {
+        $name = sanitize_key($name);
+
+        if (empty($name)) {
+            return null;
+        }
+
+        $metaKey = self::META_KEY_PREFIX . $name;
+
+        if (strlen($metaKey) > self::MAX_META_KEY_LENGTH) {
+            // A StoreLinkr metafield name may be longer than the meta_key column of WordPress, so
+            // the key is cut off. Two long names can share their first characters, the hash of the
+            // full name keeps the shortened keys apart.
+            $metaKey = substr($metaKey, 0, self::MAX_META_KEY_LENGTH - (self::KEY_HASH_LENGTH + 1))
+                . '_' . substr(md5($name), 0, self::KEY_HASH_LENGTH);
+        }
+
+        if (in_array($metaKey, self::RESERVED_META_KEYS, true)) {
+            return null;
+        }
+
+        return $metaKey;
+    }
+
+    /**
+     * StoreLinkr stores every metafield value as text, the JSON based types hold a JSON string.
+     *
+     * @param string $type
+     * @param mixed $value
+     * @return string|null
+     */
+    public static function formatValue(string $type, $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if ($type === 'boolean') {
+            if (is_bool($value)) {
+                return ($value === true) ? '1' : '0';
+            }
+
+            return in_array(strtolower(trim((string)$value)), ['1', 'true', 'yes', 'on'], true) ? '1' : '0';
+        }
+
+        if (is_array($value)) {
+            return json_encode($value);
+        }
+
+        return (string)$value;
+    }
+
+    /**
+     * @param string $type
+     * @param string $value
+     * @return array|null the decoded value for the JSON based types, null for all other types
+     */
+    public static function decodeValue(string $type, string $value): ?array
+    {
+        if (!in_array($type, self::JSON_TYPES, true)) {
+            return null;
+        }
+
+        $decoded = json_decode($value, true);
+
+        return (is_array($decoded)) ? $decoded : null;
+    }
+
+    /**
+     * @param WC_Product|WC_Product_Variable|WC_Product_Variation $product
+     * @return array
+     */
+    private static function readIndex($product): array
+    {
+        $index = $product->get_meta(self::INDEX_META_KEY, true);
+
+        if (is_string($index)) {
+            $index = json_decode($index, true);
+        }
+
+        return (is_array($index)) ? $index : [];
+    }
+
+    private static function rememberDefinitions(array $definitions): void
+    {
+        $registry = self::getDefinitions();
+        $changed = false;
+
+        foreach ($definitions as $definition) {
+            $metaKey = $definition['key'];
+
+            if (
+                isset($registry[$metaKey])
+                && $registry[$metaKey]['name'] === $definition['name']
+                && $registry[$metaKey]['type'] === $definition['type']
+            ) {
+                continue;
+            }
+
+            $registry[$metaKey] = [
+                'name' => $definition['name'],
+                'type' => $definition['type'],
+            ];
+            $changed = true;
+        }
+
+        if ($changed === false) {
+            return;
+        }
+
+        update_option(self::REGISTRY_OPTION, $registry, false);
+    }
+
+}

--- a/helpers/class.storelinkr-metafield-helper.php
+++ b/helpers/class.storelinkr-metafield-helper.php
@@ -36,6 +36,15 @@ class StoreLinkrMetafieldHelper
     public const DEFAULT_TYPE = 'single_text';
 
     /**
+     * A metafield belongs to a single StoreLinkr product, which is a WooCommerce product or, when
+     * the product is part of a variant, one of its variations.
+     */
+    public const POST_TYPES = [
+        'product',
+        'product_variation',
+    ];
+
+    /**
      * The meta_key column of WordPress is a varchar(255), a longer key is refused or truncated by
      * the database. Note that the index on the column only covers the first 191 characters.
      */
@@ -144,7 +153,8 @@ class StoreLinkrMetafieldHelper
 
     /**
      * Register all known metafields as post meta, so WordPress knows the meta keys of this shop and
-     * everything that expects registered meta can work with them.
+     * everything that expects registered meta can work with them. Every product of a variant has
+     * its own metafields, so the variations are registered as well.
      *
      * WooCommerce products are readable through the WordPress REST API, and metafields can hold
      * internal data like purchase prices, so they stay out of the REST API unless a shop opts in
@@ -153,7 +163,7 @@ class StoreLinkrMetafieldHelper
     public static function registerPostMeta(): void
     {
         foreach (self::getDefinitions() as $metaKey => $definition) {
-            register_post_meta('product', $metaKey, [
+            $args = [
                 'type' => 'string',
                 'description' => (!empty($definition['name'])) ? (string)$definition['name'] : $metaKey,
                 'single' => true,
@@ -166,7 +176,11 @@ class StoreLinkrMetafieldHelper
                 'auth_callback' => function () {
                     return current_user_can('manage_woocommerce');
                 },
-            ]);
+            ];
+
+            foreach (self::POST_TYPES as $postType) {
+                register_post_meta($postType, $metaKey, $args);
+            }
         }
     }
 

--- a/mappers/class.storelinkr-woocommerce-mapper.php
+++ b/mappers/class.storelinkr-woocommerce-mapper.php
@@ -5,6 +5,8 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
+require_once(STORELINKR_PLUGIN_DIR . 'helpers/class.storelinkr-metafield-helper.php');
+
 class StoreLinkrWooCommerceMapper
 {
 
@@ -126,6 +128,12 @@ class StoreLinkrWooCommerceMapper
                     $product->update_meta_data($key, $value, true);
                 }
             }
+        }
+
+        // Only touch the metafields when StoreLinkr sent them, older versions do not send this key
+        // at all and their products should keep the metafields of the previous sync.
+        if (isset($data['metafields']) && is_array($data['metafields'])) {
+            StoreLinkrMetafieldHelper::applyToProduct($product, $data['metafields']);
         }
 
         $product->update_meta_data('import_provider', 'STORELINKR', true);

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: storelinkr, petervw
 Tags: bol.com, amazon, kaufland, multichannel, dropshipping, marketplace, inventory sync, order automation, ecommerce, cdiscount, allegro
 Requires at least: 6.6
-Tested up to: 7.0
-Stable tag: 2.17.1
+Tested up to: 7.1
+Stable tag: 2.18.1
 Requires PHP: 8.2
 License: GPLv2 or later
 
@@ -152,6 +152,18 @@ If you want to contribute, please take a look at our [Github Repository](https:/
 == Changelog ==
 
 Please read the changelog.txt for more commit history of this plugin.
+
+= 2.18.1 =
+
+Release date: 2026-08-13
+
+#### Enhancements
+
+* Version bump for WordPress 7.1 support
+
+#### Bugfixes
+
+None
 
 = 2.17.1 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: storelinkr, petervw
 Tags: bol.com, amazon, kaufland, multichannel, dropshipping, marketplace, inventory sync, order automation, ecommerce, cdiscount, allegro
 Requires at least: 6.6
 Tested up to: 7.1
-Stable tag: 2.18.1
+Stable tag: 2.19.0
 Requires PHP: 8.2
 License: GPLv2 or later
 
@@ -152,6 +152,21 @@ If you want to contribute, please take a look at our [Github Repository](https:/
 == Changelog ==
 
 Please read the changelog.txt for more commit history of this plugin.
+
+= 2.19.0 =
+
+Release date: 2026-08-13
+
+#### Enhancements
+
+* Store all StoreLinkr product metafields, like OE numbers and manufacturer codes, as product meta
+* New Metafields tab on the product page in the admin, showing the metafields of the product
+* New template function storeLinkrGetProductMetafields() to use the metafields in your theme
+* New filter storelinkr_metafield_show_in_rest to expose a metafield through the WordPress REST API
+
+#### Bugfixes
+
+None
 
 = 2.18.1 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -160,6 +160,7 @@ Release date: 2026-08-13
 #### Enhancements
 
 * Store all StoreLinkr product metafields, like OE numbers and manufacturer codes, as product meta
+* Every product of a variant keeps its own metafields on the variation itself
 * New Metafields tab on the product page in the admin, showing the metafields of the product
 * New template function storeLinkrGetProductMetafields() to use the metafields in your theme
 * New filter storelinkr_metafield_show_in_rest to expose a metafield through the WordPress REST API

--- a/storelinkr.php
+++ b/storelinkr.php
@@ -7,7 +7,7 @@
 Plugin Name: StoreLinkr
 Plugin URI: https://storelinkr.com/en/integrations/wordpress-woocommerce-dropshipment
 Description: Stop manual work: the all-in-one platform for complete online store automation. Integrate with marketplaces, product feeds, and suppliers.
-Version: 2.17.1
+Version: 2.18.1
 Author: StoreLinkr
 Author URI: https://storelinkr.com
 License: GPLv2 or later
@@ -22,7 +22,7 @@ if (!defined('ABSPATH')) {
 
 define('STORELINKR_PLUGIN_BASENAME', plugin_basename(__FILE__));
 define('STORELINKR_PLUGIN_FILE', __FILE__);
-define('STORELINKR_VERSION', '2.17.1');
+define('STORELINKR_VERSION', '2.18.1');
 define('STORELINKR_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('STORELINKR_PLUGIN_URL', plugin_dir_url(__FILE__));
 

--- a/storelinkr.php
+++ b/storelinkr.php
@@ -7,7 +7,7 @@
 Plugin Name: StoreLinkr
 Plugin URI: https://storelinkr.com/en/integrations/wordpress-woocommerce-dropshipment
 Description: Stop manual work: the all-in-one platform for complete online store automation. Integrate with marketplaces, product feeds, and suppliers.
-Version: 2.18.1
+Version: 2.19.0
 Author: StoreLinkr
 Author URI: https://storelinkr.com
 License: GPLv2 or later
@@ -22,15 +22,17 @@ if (!defined('ABSPATH')) {
 
 define('STORELINKR_PLUGIN_BASENAME', plugin_basename(__FILE__));
 define('STORELINKR_PLUGIN_FILE', __FILE__);
-define('STORELINKR_VERSION', '2.18.1');
+define('STORELINKR_VERSION', '2.19.0');
 define('STORELINKR_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('STORELINKR_PLUGIN_URL', plugin_dir_url(__FILE__));
 
 require_once(STORELINKR_PLUGIN_DIR . 'class.storelinkr.php');
 require_once(STORELINKR_PLUGIN_DIR . 'class.storelinkr-rest-api.php');
 require_once(STORELINKR_PLUGIN_DIR . 'class.storelinkr-frontend.php');
+require_once(STORELINKR_PLUGIN_DIR . 'helpers/class.storelinkr-metafield-helper.php');
 
 add_action('init', ['StoreLinkr', 'init']);
+add_action('init', ['StoreLinkrMetafieldHelper', 'registerPostMeta'], 20);
 
 $storelinkrRestApi = new StoreLinkrRestApi(STORELINKR_VERSION);
 add_action('rest_api_init', [$storelinkrRestApi, 'init']);
@@ -140,6 +142,28 @@ if (!function_exists('storeLinkrGetProductStockInformation')) {
             $product->get_meta('import_source'),
             $product->get_meta('ean')
         );
+    }
+}
+
+if (!function_exists('storeLinkrGetProductMetafields')) {
+    /**
+     * Fetch all StoreLinkr metafields of a product, for example the OE numbers or manufacturer codes.
+     *
+     * Every metafield is returned as an array with the StoreLinkr name, the metafield type, the
+     * WordPress meta key, the raw value and, for the datatable and JSON types, the decoded value.
+     *
+     * @param int $productId
+     * @return array
+     */
+    function storeLinkrGetProductMetafields(int $productId): array
+    {
+        $product = wc_get_product($productId);
+
+        if (!$product instanceof WC_Product) {
+            return [];
+        }
+
+        return StoreLinkrMetafieldHelper::getProductMetafields($product);
     }
 }
 

--- a/tests/BuildProductVariantOptionsTest.php
+++ b/tests/BuildProductVariantOptionsTest.php
@@ -53,7 +53,7 @@ class BuildProductVariantOptionsTest extends TestCase
         
         // Mock wc_delete_product_transients
         if (!function_exists('wc_delete_product_transients')) {
-            function wc_delete_product_transients($id) {
+            function wc_delete_product_transients($id = 0) {
                 return true;
             }
         }

--- a/tests/MetafieldTest.php
+++ b/tests/MetafieldTest.php
@@ -1,0 +1,276 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once STORELINKR_PLUGIN_DIR . 'helpers/class.storelinkr-metafield-helper.php';
+
+/**
+ * Covers the StoreLinkr product metafields (OE numbers, manufacturer codes, ...) that are stored
+ * as WooCommerce product meta.
+ */
+class MetafieldTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        global $storelinkrTestOptions;
+        $storelinkrTestOptions = [];
+    }
+
+    public function testMetafieldsAreStoredAsPrefixedProductMeta(): void
+    {
+        $product = new StoreLinkrMetafieldTestProduct();
+
+        StoreLinkrMetafieldHelper::applyToProduct($product, [
+            [
+                'name' => 'oe_numbers',
+                'type' => 'datatable',
+                'value' => '[{"merk":"Bosch","code":"0 986 452 041"}]',
+            ],
+            [
+                'name' => 'stock_strategy',
+                'type' => 'single_text',
+                'value' => 'Dropship',
+            ],
+        ]);
+
+        self::assertSame(
+            '[{"merk":"Bosch","code":"0 986 452 041"}]',
+            $product->get_meta('storelinkr_oe_numbers', true)
+        );
+        self::assertSame('Dropship', $product->get_meta('storelinkr_stock_strategy', true));
+    }
+
+    public function testMetafieldsAreRegisteredForThisShop(): void
+    {
+        $product = new StoreLinkrMetafieldTestProduct();
+
+        StoreLinkrMetafieldHelper::applyToProduct($product, [
+            [
+                'name' => 'manufacturer_codes',
+                'type' => 'datatable',
+                'value' => '[{"merk":"Febi","type":"OE","code":"12345"}]',
+            ],
+        ]);
+
+        self::assertSame([
+            'storelinkr_manufacturer_codes' => [
+                'name' => 'manufacturer_codes',
+                'type' => 'datatable',
+            ],
+        ], StoreLinkrMetafieldHelper::getDefinitions());
+    }
+
+    public function testGetProductMetafieldsDecodesTheDatatableValue(): void
+    {
+        $product = new StoreLinkrMetafieldTestProduct();
+
+        StoreLinkrMetafieldHelper::applyToProduct($product, [
+            [
+                'name' => 'oe_numbers',
+                'type' => 'datatable',
+                'value' => '[{"merk":"Bosch","code":"0 986 452 041"}]',
+            ],
+            [
+                'name' => 'is_universal',
+                'type' => 'boolean',
+                'value' => 'true',
+            ],
+        ]);
+
+        self::assertSame([
+            [
+                'name' => 'oe_numbers',
+                'type' => 'datatable',
+                'key' => 'storelinkr_oe_numbers',
+                'value' => '[{"merk":"Bosch","code":"0 986 452 041"}]',
+                'decoded' => [
+                    ['merk' => 'Bosch', 'code' => '0 986 452 041'],
+                ],
+            ],
+            [
+                'name' => 'is_universal',
+                'type' => 'boolean',
+                'key' => 'storelinkr_is_universal',
+                'value' => '1',
+                'decoded' => null,
+            ],
+        ], StoreLinkrMetafieldHelper::getProductMetafields($product));
+    }
+
+    public function testRemovedMetafieldsAreDeletedOnTheNextSync(): void
+    {
+        $product = new StoreLinkrMetafieldTestProduct();
+
+        StoreLinkrMetafieldHelper::applyToProduct($product, [
+            ['name' => 'oe_numbers', 'type' => 'datatable', 'value' => '[{"merk":"Bosch","code":"1"}]'],
+            ['name' => 'stock_strategy', 'type' => 'single_text', 'value' => 'Dropship'],
+        ]);
+
+        StoreLinkrMetafieldHelper::applyToProduct($product, [
+            ['name' => 'oe_numbers', 'type' => 'datatable', 'value' => '[{"merk":"Bosch","code":"2"}]'],
+        ]);
+
+        self::assertSame('[{"merk":"Bosch","code":"2"}]', $product->get_meta('storelinkr_oe_numbers', true));
+        self::assertNull($product->get_meta('storelinkr_stock_strategy', true));
+        self::assertCount(1, StoreLinkrMetafieldHelper::getProductMetafields($product));
+    }
+
+    public function testProductMetaIsUntouchedWhenNoMetafieldsAreSent(): void
+    {
+        $product = new StoreLinkrMetafieldTestProduct();
+
+        StoreLinkrMetafieldHelper::applyToProduct($product, [
+            ['name' => 'oe_numbers', 'type' => 'datatable', 'value' => '[{"merk":"Bosch","code":"1"}]'],
+        ]);
+
+        // The mapper only calls the helper when StoreLinkr sent the metafields key, so a payload
+        // without metafields may never clear the meta of the previous sync.
+        $data = ['name' => 'Product without metafields'];
+        self::assertFalse(isset($data['metafields']));
+        self::assertSame('[{"merk":"Bosch","code":"1"}]', $product->get_meta('storelinkr_oe_numbers', true));
+    }
+
+    /**
+     * Only the types with their own handling change the stored value: a boolean becomes 1 or 0 and
+     * a datatable or JSON value is decoded when it is read back. All other types are stored as the
+     * text StoreLinkr sent.
+     *
+     * @dataProvider metafieldTypeProvider
+     */
+    public function testEveryMetafieldTypeIsStoredAndReadBack(
+        string $type,
+        $value,
+        string $expectedStoredValue,
+        ?array $expectedDecoded
+    ): void {
+        $product = new StoreLinkrMetafieldTestProduct();
+
+        StoreLinkrMetafieldHelper::applyToProduct($product, [
+            ['name' => 'test_field', 'type' => $type, 'value' => $value],
+        ]);
+
+        self::assertSame($expectedStoredValue, $product->get_meta('storelinkr_test_field', true));
+        self::assertSame([
+            [
+                'name' => 'test_field',
+                'type' => $type,
+                'key' => 'storelinkr_test_field',
+                'value' => $expectedStoredValue,
+                'decoded' => $expectedDecoded,
+            ],
+        ], StoreLinkrMetafieldHelper::getProductMetafields($product));
+    }
+
+    public function metafieldTypeProvider(): array
+    {
+        return [
+            'datatable' => [
+                'datatable',
+                '[{"merk":"Bosch","code":"0 986 452 041"}]',
+                '[{"merk":"Bosch","code":"0 986 452 041"}]',
+                [['merk' => 'Bosch', 'code' => '0 986 452 041']],
+            ],
+            'json' => [
+                'json',
+                '{"overlay_label":"Nieuw"}',
+                '{"overlay_label":"Nieuw"}',
+                ['overlay_label' => 'Nieuw'],
+            ],
+            'broken json stays text' => ['json', '{not json', '{not json', null],
+            'single_text' => ['single_text', 'Dropship', 'Dropship', null],
+            'multiple_text' => ['multiple_text', "Regel een\nRegel twee", "Regel een\nRegel twee", null],
+            'html_text' => [
+                'html_text',
+                '<p>Draai aan met <strong>45 Nm</strong></p>',
+                '<p>Draai aan met <strong>45 Nm</strong></p>',
+                null,
+            ],
+            'boolean true' => ['boolean', 'true', '1', null],
+            'boolean one' => ['boolean', '1', '1', null],
+            'boolean false' => ['boolean', 'false', '0', null],
+            'boolean zero' => ['boolean', '0', '0', null],
+            'number' => ['number', '45.5', '45.5', null],
+            'date' => ['date', '2026-09-01', '2026-09-01', null],
+            'color' => ['color', '#1e3346', '#1e3346', null],
+            'email' => ['email', 'support@example.com', 'support@example.com', null],
+            'url' => ['url', 'https://example.com/datasheet.pdf', 'https://example.com/datasheet.pdf', null],
+        ];
+    }
+
+    public function testALongMetafieldNameFitsInTheWordPressMetaKeyColumn(): void
+    {
+        $product = new StoreLinkrMetafieldTestProduct();
+        $name = str_repeat('oe_number_', 30);
+
+        StoreLinkrMetafieldHelper::applyToProduct($product, [
+            ['name' => $name, 'type' => 'single_text', 'value' => 'A very long metafield name'],
+        ]);
+
+        $metafields = StoreLinkrMetafieldHelper::getProductMetafields($product);
+
+        self::assertCount(1, $metafields);
+        self::assertSame(
+            StoreLinkrMetafieldHelper::MAX_META_KEY_LENGTH,
+            strlen($metafields[0]['key'])
+        );
+        self::assertSame($name, $metafields[0]['name']);
+        self::assertSame('A very long metafield name', $metafields[0]['value']);
+    }
+
+    public function testTwoLongMetafieldNamesDoNotShareOneMetaKey(): void
+    {
+        $product = new StoreLinkrMetafieldTestProduct();
+        $prefix = str_repeat('oe_number_', 30);
+
+        StoreLinkrMetafieldHelper::applyToProduct($product, [
+            ['name' => $prefix . 'first', 'type' => 'single_text', 'value' => 'First'],
+            ['name' => $prefix . 'second', 'type' => 'single_text', 'value' => 'Second'],
+        ]);
+
+        $metafields = StoreLinkrMetafieldHelper::getProductMetafields($product);
+
+        self::assertCount(2, $metafields);
+        self::assertNotSame($metafields[0]['key'], $metafields[1]['key']);
+        self::assertSame('First', $metafields[0]['value']);
+        self::assertSame('Second', $metafields[1]['value']);
+    }
+
+    public function testMetafieldsWithoutAUsableNameAreSkipped(): void
+    {
+        $product = new StoreLinkrMetafieldTestProduct();
+
+        StoreLinkrMetafieldHelper::applyToProduct($product, [
+            ['name' => '///', 'type' => 'single_text', 'value' => 'Skipped'],
+            ['name' => 'variant_ids', 'type' => 'single_text', 'value' => 'Reserved meta key'],
+            ['name' => 'empty_value', 'type' => 'single_text', 'value' => null],
+        ]);
+
+        self::assertSame([], StoreLinkrMetafieldHelper::getProductMetafields($product));
+        self::assertNull($product->get_meta('storelinkr_variant_ids', true));
+    }
+}
+
+/**
+ * Minimal WC_Data stand-in that stores the meta in memory.
+ */
+class StoreLinkrMetafieldTestProduct
+{
+    private array $meta = [];
+
+    public function update_meta_data($key, $value, $meta_id = 0)
+    {
+        $this->meta[$key] = $value;
+    }
+
+    public function delete_meta_data($key)
+    {
+        unset($this->meta[$key]);
+    }
+
+    public function get_meta($key, $single = false)
+    {
+        return $this->meta[$key] ?? null;
+    }
+}

--- a/tests/MetafieldTest.php
+++ b/tests/MetafieldTest.php
@@ -237,6 +237,51 @@ class MetafieldTest extends TestCase
         self::assertSame('Second', $metafields[1]['value']);
     }
 
+    /**
+     * A variant sends its metafields per product, so they end up on the variation and not on the
+     * variable product that holds it.
+     */
+    public function testTheMapperAppliesTheMetafieldsOfAVariationOption(): void
+    {
+        require_once STORELINKR_PLUGIN_DIR . 'mappers/class.storelinkr-woocommerce-mapper.php';
+
+        $variation = new StoreLinkrMetafieldTestProduct();
+
+        StoreLinkrWooCommerceMapper::convertRequestToProduct($variation, [
+            'name' => 'Accu 60Ah',
+            'salesPrice' => 9995,
+            'options' => ['Capaciteit' => '60Ah'],
+            'metafields' => [
+                ['name' => 'oe_numbers', 'type' => 'datatable', 'value' => '[{"merk":"Bosch","code":"60-AH-001"}]'],
+            ],
+        ]);
+
+        self::assertSame(
+            '[{"merk":"Bosch","code":"60-AH-001"}]',
+            $variation->get_meta('storelinkr_oe_numbers', true)
+        );
+    }
+
+    public function testTheMapperLeavesAVariationAloneWithoutMetafields(): void
+    {
+        require_once STORELINKR_PLUGIN_DIR . 'mappers/class.storelinkr-woocommerce-mapper.php';
+
+        $variation = new StoreLinkrMetafieldTestProduct();
+        StoreLinkrMetafieldHelper::applyToProduct($variation, [
+            ['name' => 'oe_numbers', 'type' => 'datatable', 'value' => '[{"merk":"Bosch","code":"60-AH-001"}]'],
+        ]);
+
+        StoreLinkrWooCommerceMapper::convertRequestToProduct($variation, [
+            'name' => 'Accu 60Ah',
+            'salesPrice' => 9995,
+        ]);
+
+        self::assertSame(
+            '[{"merk":"Bosch","code":"60-AH-001"}]',
+            $variation->get_meta('storelinkr_oe_numbers', true)
+        );
+    }
+
     public function testMetafieldsWithoutAUsableNameAreSkipped(): void
     {
         $product = new StoreLinkrMetafieldTestProduct();
@@ -253,9 +298,10 @@ class MetafieldTest extends TestCase
 }
 
 /**
- * Minimal WC_Data stand-in that stores the meta in memory.
+ * Minimal WC_Data stand-in that stores the meta in memory. Extends the WC_Product_Variation stub of
+ * the bootstrap, so it passes the type hint of the mapper and covers a product of a variant.
  */
-class StoreLinkrMetafieldTestProduct
+class StoreLinkrMetafieldTestProduct extends WC_Product_Variation
 {
     private array $meta = [];
 
@@ -272,5 +318,12 @@ class StoreLinkrMetafieldTestProduct
     public function get_meta($key, $single = false)
     {
         return $this->meta[$key] ?? null;
+    }
+
+    // Swallow the WooCommerce setters and getters the mapper touches, method_exists() returns false
+    // for these so the mapper skips everything that is not meta.
+    public function __call($name, $arguments)
+    {
+        return null;
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -55,6 +55,46 @@ if (!function_exists('flush_rewrite_rules')) {
     }
 }
 
+if (!function_exists('wc_attribute_taxonomy_name')) {
+    function wc_attribute_taxonomy_name($slug) {
+        return 'pa_' . $slug;
+    }
+}
+
+if (!function_exists('register_taxonomy')) {
+    function register_taxonomy($taxonomy, $objectType, $args = []) {
+        return true;
+    }
+}
+
+if (!function_exists('apply_filters')) {
+    function apply_filters($hook, $value) {
+        return $value;
+    }
+}
+
+if (!function_exists('is_wp_error')) {
+    function is_wp_error($thing) {
+        return $thing instanceof WP_Error;
+    }
+}
+
+if (!class_exists('WP_Error')) {
+    class WP_Error {
+        private $code;
+        private $message;
+
+        public function __construct($code = '', $message = '') {
+            $this->code = $code;
+            $this->message = $message;
+        }
+
+        public function get_error_message() {
+            return $this->message;
+        }
+    }
+}
+
 if (!function_exists('term_exists')) {
     function term_exists($term, $taxonomy) {
         return false;
@@ -96,12 +136,19 @@ if (!class_exists('WC_Product_Variation')) {
         private $id;
         private $parent_id;
         private $attributes = [];
-        
+        private $regular_price = '';
+
         public function set_parent_id($id) { $this->parent_id = $id; }
         public function set_attributes($attributes) { $this->attributes = $attributes; }
+        public function get_attributes() { return $this->attributes; }
         public function save() { return true; }
         public function get_id() { return $this->id ?: rand(1000, 9999); }
         public function update_meta_data($key, $value, $unique = false) { }
+        public function set_regular_price($price) { $this->regular_price = $price; }
+        public function get_regular_price() { return $this->regular_price; }
+
+        // Swallow any other WooCommerce setter/getter the mapper touches during tests.
+        public function __call($name, $arguments) { return null; }
     }
 }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -31,6 +31,42 @@ if (!function_exists('sanitize_title')) {
     }
 }
 
+if (!function_exists('sanitize_key')) {
+    function sanitize_key($key) {
+        return preg_replace('/[^a-z0-9_\-]/', '', strtolower(trim($key)));
+    }
+}
+
+if (!function_exists('get_option')) {
+    function get_option($option, $default = false) {
+        global $storelinkrTestOptions;
+
+        return $storelinkrTestOptions[$option] ?? $default;
+    }
+}
+
+if (!function_exists('update_option')) {
+    function update_option($option, $value, $autoload = null) {
+        global $storelinkrTestOptions;
+
+        $storelinkrTestOptions[$option] = $value;
+
+        return true;
+    }
+}
+
+if (!function_exists('register_post_meta')) {
+    function register_post_meta($postType, $metaKey, $args = []) {
+        return true;
+    }
+}
+
+if (!function_exists('current_user_can')) {
+    function current_user_can($capability) {
+        return true;
+    }
+}
+
 if (!function_exists('taxonomy_exists')) {
     function taxonomy_exists($taxonomy) {
         return false; // For testing, assume taxonomies don't exist
@@ -68,7 +104,7 @@ if (!function_exists('register_taxonomy')) {
 }
 
 if (!function_exists('apply_filters')) {
-    function apply_filters($hook, $value) {
+    function apply_filters($hook, $value, ...$args) {
         return $value;
     }
 }


### PR DESCRIPTION
## Summary

Started as a version bump, now also carries the metafield support for the Accudeal complaint (#12618): the OE numbers and manufacturer codes were missing in WooCommerce.

### Product metafields (SPD-2025)

StoreLinkr sends the metafields of a product with every export (sitepack-connect PR #1119), this stores them:

- Every metafield becomes a `storelinkr_<name>` product meta, sanitized and cut off at the 255 characters of the WordPress `meta_key` column, with an md5 suffix of the full name so two long names never share one key.
- A product of a variant keeps its own metafields on the variation itself, not on the variable product that holds it. Simple products, bulk upserts and variants all run through the shared product mapper.
- An index in `_storelinkr_metafields` records what a product has, so a metafield removed in StoreLinkr is removed here on the next sync. A payload without a `metafields` key leaves the existing meta alone, so an older StoreLinkr version never wipes the data.
- Values are stored as the text StoreLinkr sent. Only a boolean is normalized to `1` or `0`, and a datatable or JSON value is decoded when it is read back.
- All known keys are registered with `register_post_meta` for both `product` and `product_variation`, but with `show_in_rest` off. WooCommerce products are readable through the WordPress REST API and a metafield can hold internal data such as a purchase price, so a shop opts in per key with the new `storelinkr_metafield_show_in_rest` filter.
- New **Metafields** tab on the product page in the admin, with datatables as a table and JSON pretty printed. For a variable product it lists the metafields per variation.
- New template function `storeLinkrGetProductMetafields($productId)` for themes, including the decoded value per metafield.

### Version bump

- Plugin version `2.17.1` → `2.19.0` (`storelinkr.php` header and `STORELINKR_VERSION`)
- `Tested up to` `7.0` → `7.1` and `Stable tag` `2.19.0` in `readme.txt`
- Changelog entries in both `readme.txt` and `changelog.txt`

Versioned as `2.19.0` because this adds features. PR #56 (`spd-1947`) still claims `2.18.0`, so a small conflict at the top of the changelog may need resolving depending on which merges first.

## Tests

`./vendor/bin/phpunit` green (29 tests). `tests/MetafieldTest.php` covers every metafield type through a data provider, the cleanup of removed metafields, the untouched meta when no metafields are sent, the meta key length, and the mapper applying the metafields to a variation.

Verified end to end against a local WordPress with WooCommerce: meta written and read back, removed metafield cleaned up, a variant with two options where each variation keeps its own OE numbers, the admin tab rendered for both a simple and a variable product, and the REST response confirmed empty until the filter opts a key in.